### PR TITLE
Use elm/url builder for url building/encoding

### DIFF
--- a/src/Servant/To/Elm.hs
+++ b/src/Servant/To/Elm.hs
@@ -223,8 +223,9 @@ elmEndpointDefinition urlBase moduleName endpoint =
 
     elmUrl =
       Expression.apps
-        "Url.Builder.absolute"
-        [ Expression.List $ vacuous urlBase : fmap elmPathSegment numberedPathSegments
+        "Url.Builder.crossOrigin"
+        [ vacuous urlBase
+        , Expression.List $  fmap elmPathSegment numberedPathSegments
         , Expression.App "List.concat" $ Expression.List elmParams
         ]
 


### PR DESCRIPTION
Removes `[]=` from list params, since servant [supports](https://hackage.haskell.org/package/servant-0.18/docs/Servant-API.html#t:QueryParams) not adding that, seems cleaner, not sure if it matters.

Removes the need for `Maybe.Extra.unwrap` by using `Maybe.withDefault` + `Maybe.map`

closes #5 