### PR TITLE
Allow only alphanum in generated Elm endpoint function names

### DIFF
--- a/src/Servant/To/Elm.hs
+++ b/src/Servant/To/Elm.hs
@@ -55,7 +55,7 @@ elmEndpointDefinition urlBase moduleName endpoint =
     (error "expression not closed" <$> lambdaArgs argNames elmLambdaBody)
   where
     functionName =
-      case _functionName endpoint of
+      case Text.filter Char.isAlphaNum <$> _functionName endpoint of
         [] ->
           ""
 


### PR DESCRIPTION
Currently generating functions for paths that include `-` will generate invalid elm function name syntax. This change only allows alpha numeric chars. Which might still be too tolerant, but it filters some of the commonly used symbols in urls.

As I'm writing this I'm wondering if this logic should be part of elm-syntax, any thoughts on that?