### PR TITLE
Support Servant up to 0.18.3 (close #12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+## 0.4.3.0
+
+- Add `HasElmEndpoints` instance for the new `Servant.NoContentVerb` type. Requires `servant` 0.17 or later.
+
 ## 0.4.2.0
 
 - Use the `Url.Builder` module from `elm/url` to build URLs (https://github.com/folq/servant-to-elm/pull/6 by https://github.com/rl-king)

--- a/examples/UserAPI.hs
+++ b/examples/UserAPI.hs
@@ -5,7 +5,7 @@
 {-# language OverloadedStrings #-}
 {-# language TypeApplications #-}
 {-# language TypeOperators #-}
-module UserAPI where
+module Main where
 
 import qualified Data.Aeson as Aeson
 import Data.Foldable
@@ -39,7 +39,7 @@ instance HasElmEncoder Aeson.Value User where
 
 type UserAPI
   = "user" :> Get '[JSON] User
-  :<|> "user" :> ReqBody '[JSON] User :> PostNoContent '[JSON] NoContent
+  :<|> "user" :> ReqBody '[JSON] User :> PostNoContent
 
 main :: IO ()
 main = do

--- a/package.yaml
+++ b/package.yaml
@@ -27,7 +27,7 @@ dependencies:
 - elm-syntax >= 0.3.0 && < 0.3.1
 - haskell-to-elm >= 0.3.0 && < 0.3.3
 - http-types >= 0.12.0
-- servant >= 0.16.0 && < 0.19
+- servant >= 0.17 && < 0.19
 - servant-multipart >= 0.11.0
 - text >= 1.2.0
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                servant-to-elm
-version:             0.4.2.0
+version:             0.4.3.0
 github:              "folq/servant-to-elm"
 license:             BSD3
 author:              "Olle Fredriksson"

--- a/package.yaml
+++ b/package.yaml
@@ -27,7 +27,7 @@ dependencies:
 - elm-syntax >= 0.3.0 && < 0.3.1
 - haskell-to-elm >= 0.3.0 && < 0.3.3
 - http-types >= 0.12.0
-- servant >= 0.16.0 && < 0.17.0
+- servant >= 0.16.0 && < 0.19
 - servant-multipart >= 0.11.0
 - text >= 1.2.0
 

--- a/servant-to-elm.cabal
+++ b/servant-to-elm.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 861a89a05c905243e8884c7e1467bb3b87300b920f2961b3782c602b3ff5389d
+-- hash: e2f48584ccf073f959dff499b5f01ecd10c1249e7a292fb998ff01adbc99baaf
 
 name:           servant-to-elm
-version:        0.4.2.0
+version:        0.4.3.0
 synopsis:       Automatically generate Elm clients for Servant APIs
 description:    Please see the README on GitHub at <https://github.com/folq/servant-to-elm#readme>
 category:       Servant, API, Elm, Compiler

--- a/servant-to-elm.cabal
+++ b/servant-to-elm.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2b8538c318ad2d1498a9e8d6e1f59dbfce64e0bc043e3e819daedb08e6dd1187
+-- hash: 861a89a05c905243e8884c7e1467bb3b87300b920f2961b3782c602b3ff5389d
 
 name:           servant-to-elm
 version:        0.4.2.0
@@ -49,7 +49,7 @@ library
     , elm-syntax ==0.3.0.*
     , haskell-to-elm >=0.3.0 && <0.3.3
     , http-types >=0.12.0
-    , servant >=0.16.0 && <0.19
+    , servant >=0.17 && <0.19
     , servant-multipart >=0.11.0
     , text >=1.2.0
   default-language: Haskell2010
@@ -101,7 +101,7 @@ test-suite servant-to-elm-test
     , http-types >=0.12.0
     , prettyprinter >=1.2
     , process >=1.6
-    , servant >=0.16.0 && <0.19
+    , servant >=0.17 && <0.19
     , servant-multipart >=0.11.0
     , servant-to-elm
     , temporary >=1.3

--- a/servant-to-elm.cabal
+++ b/servant-to-elm.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.3.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 600be4c131caa5290786ee59b7f6bb34535ebd50ff0b013c8529535fae575747
+-- hash: 2b8538c318ad2d1498a9e8d6e1f59dbfce64e0bc043e3e819daedb08e6dd1187
 
 name:           servant-to-elm
 version:        0.4.2.0
@@ -46,10 +46,10 @@ library
       aeson >=1.4.0
     , base >=4.7 && <5
     , bound >=2.0.0
-    , elm-syntax >=0.3.0 && <0.3.1
+    , elm-syntax ==0.3.0.*
     , haskell-to-elm >=0.3.0 && <0.3.3
     , http-types >=0.12.0
-    , servant >=0.16.0 && <0.17.0
+    , servant >=0.16.0 && <0.19
     , servant-multipart >=0.11.0
     , text >=1.2.0
   default-language: Haskell2010
@@ -65,7 +65,7 @@ executable user-example
       aeson >=1.4.0
     , base >=4.7 && <5
     , bound >=2.0.0
-    , elm-syntax >=0.3.0 && <0.3.1
+    , elm-syntax ==0.3.0.*
     , generics-sop
     , haskell-to-elm >=0.3.0 && <0.3.3
     , http-types >=0.12.0
@@ -93,7 +93,7 @@ test-suite servant-to-elm-test
     , bound >=2.0.0
     , bytestring >=0.10
     , directory >=1.3
-    , elm-syntax >=0.3.0 && <0.3.1
+    , elm-syntax ==0.3.0.*
     , filepath >=1.4
     , generics-sop >=0.4
     , haskell-to-elm >=0.3.0 && <0.3.3
@@ -101,7 +101,7 @@ test-suite servant-to-elm-test
     , http-types >=0.12.0
     , prettyprinter >=1.2
     , process >=1.6
-    , servant >=0.16.0 && <0.17.0
+    , servant >=0.16.0 && <0.19
     , servant-multipart >=0.11.0
     , servant-to-elm
     , temporary >=1.3

--- a/src/Servant/To/Elm.hs
+++ b/src/Servant/To/Elm.hs
@@ -363,6 +363,18 @@ instance Servant.ReflectMethod method => HasElmEndpoints (Servant.Verb method 20
         method =
           Servant.reflectMethod $ Proxy @method
 
+instance Servant.ReflectMethod method => HasElmEndpoints (Servant.NoContentVerb method) where
+  elmEndpoints' prefix =
+      [ prefix
+        { _method = method
+        , _returnType = Just $ Left Servant.NoContent
+        , _functionName = Text.toLower (Text.decodeUtf8 method) : _functionName prefix
+        }
+      ]
+      where
+        method =
+          Servant.reflectMethod $ Proxy @method
+
 instance
   ( Servant.SBoolI (Servant.FoldRequired mods)
   , KnownSymbol symbol

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.0
+resolver: lts-18.13
 packages:
 - .
 extra-deps:

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -10,7 +10,7 @@ import qualified Data.List as List
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Text.Encoding (encodeUtf8)
-import qualified Data.Text.Prettyprint.Doc as Pretty
+import qualified Prettyprinter
 import System.Directory
 import System.FilePath
 import System.IO.Temp
@@ -35,7 +35,7 @@ spec = do
       withSystemTempDirectory
         "servant-to-elm" -- temp dir name template
 
-testElmClient :: HashMap [Text] (Pretty.Doc ann) -> FilePath -> IO ()
+testElmClient :: HashMap [Text] (Prettyprinter.Doc ann) -> FilePath -> IO ()
 testElmClient elmModules tempDir = do
   let srcDir = tempDir </> "src"
   createDirectory srcDir
@@ -55,7 +55,7 @@ testElmClient elmModules tempDir = do
       withCurrentDirectory tempDir $
         callCommand "elm make src/**.elm"
 
-writeElmModule :: FilePath -> [Text] -> Pretty.Doc ann -> IO ()
+writeElmModule :: FilePath -> [Text] -> Prettyprinter.Doc ann -> IO ()
 writeElmModule srcDir moduleName content =
   BS.writeFile
     path

--- a/test/TestExampleServer.hs
+++ b/test/TestExampleServer.hs
@@ -15,12 +15,12 @@ module TestExampleServer where
 import qualified Data.Aeson as Aeson
 import Data.HashMap.Strict (HashMap)
 import Data.Text (Text)
-import qualified Data.Text.Prettyprint.Doc as Pretty
 import GHC.Generics
 import qualified Generics.SOP as SOP
 import qualified Language.Elm.Definition as Elm (Definition)
 import qualified Language.Elm.Pretty as Pretty
 import qualified Language.Elm.Simplification as Simplification
+import qualified Prettyprinter
 import Servant.API
 import Servant.To.Elm
 
@@ -45,9 +45,9 @@ instance HasElmEncoder Aeson.Value User where
 
 type UserAPI
   = "user" :> Get '[JSON] User
-  :<|> "user" :> ReqBody '[JSON] User :> PostNoContent '[JSON] NoContent
+  :<|> "user" :> ReqBody '[JSON] User :> PostNoContent
 
-definitionModules :: HashMap [Text] (Pretty.Doc ann)
+definitionModules :: HashMap [Text] (Prettyprinter.Doc ann)
 definitionModules =
   Pretty.modules (Simplification.simplifyDefinition <$> definitions)
   where
@@ -56,7 +56,7 @@ definitionModules =
       map (elmEndpointDefinition "Config.urlBase" ["Api"]) (elmEndpoints @UserAPI)
         <> jsonDefinitions @User
 
-requestInfoModules :: HashMap [Text] (Pretty.Doc ann)
+requestInfoModules :: HashMap [Text] (Prettyprinter.Doc ann)
 requestInfoModules =
   Pretty.modules (Simplification.simplifyDefinition <$> definitions)
   where


### PR DESCRIPTION
+ Add `HasElmEndpoints (Servant.NoContentVerb method)` instance.
+ Raise `servant` upper bound
+ Update tests and examples
+ Update lts in stack.yaml to the latest
+ Update Prettyprinter import to fix deprecation